### PR TITLE
Removing the need to write quote regex backwards for custom quote header

### DIFF
--- a/src/EmailReplyParser/Email.php
+++ b/src/EmailReplyParser/Email.php
@@ -21,10 +21,6 @@ class Email
         '/^(On\s(.+)wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
     );
 
-    protected $quoteHeadersReverseRegex = array(
-        '/^:etorw.*nO$/s',
-    );
-
     /**
      * @var array
      */
@@ -151,23 +147,10 @@ class Email
         $this->quoteHeadersRegex = $quoteHeadersRegex;
     }
 
-    /**
-     * @return array
-     */
-    public function getQuoteHeadersReverseRegex()
-    {
-        return $this->quoteHeadersReverseRegex;
-    }
-
-    public function setQuoteHeadersReverseRegex(array $quoteHeadersReverseRegex)
-    {
-        $this->quoteHeadersReverseRegex = $quoteHeadersReverseRegex;
-    }
-
     private function isQuoteHeader($line)
     {
-        foreach ($this->quoteHeadersReverseRegex as $regex) {
-            if (preg_match($regex, $line)) {
+        foreach ($this->quoteHeadersRegex as $regex) {
+            if (preg_match($regex, strrev($line))) {
                 return true;
             }
         }

--- a/tests/EmailReplyParser/Tests/EmailTest.php
+++ b/tests/EmailReplyParser/Tests/EmailTest.php
@@ -157,10 +157,6 @@ I am currently using the Java HTTP API.\n", (string) $reply[0]);
         $regex[] = '/^(\d{4}(.+)rta:)$/ms';
         $this->email->setQuoteHeadersRegex($regex);
 
-        $regex   = $this->email->getQuoteHeadersReverseRegex();
-        $regex[] = '/^:atr.*\d{4}$/s';
-        $this->email->setQuoteHeadersReverseRegex($regex);
-
         $reply = $this->email->read($this->getFixtures('email_custom_quote_header.txt'));
 
         $this->assertEquals('Thank you!', (string) $reply[0]);
@@ -171,10 +167,6 @@ I am currently using the Java HTTP API.\n", (string) $reply[0]);
         $regex   = $this->email->getQuoteHeadersRegex();
         $regex[] = '/^(From\: .+ .+test\@webdomain\.com.+)/ms';
         $this->email->setQuoteHeadersRegex($regex);
-
-        $regex   = $this->email->getQuoteHeadersReverseRegex();
-        $regex[] = '/.+'.strrev('com').'\.'.strrev('webdomain').'\@'.strrev('test').'.+/s';
-        $this->email->setQuoteHeadersReverseRegex($regex);
 
         $this->email->read($this->getFixtures('email_customer_quote_header_2.txt'));
 


### PR DESCRIPTION
With this pull request we don't need to duplicate our custom quote regex by have to write it backward.. Regular expression is already annoying as it is. =x

Let me know if you see any problem. =]
