### PR TITLE
Fixes signature regexp

### DIFF
--- a/src/EmailReplyParser/Email.php
+++ b/src/EmailReplyParser/Email.php
@@ -15,7 +15,7 @@ namespace EmailReplyParser;
  */
 class Email
 {
-    const SIG_REGEX = '/(--|__|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)/s';
+    const SIG_REGEX = '/(^--|^__|\w-$)|(^(\w+\s*){1,3} ym morf tneS$)/s';
 
     protected $quoteHeadersRegex = array(
         '/^(On\s(.+)wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:


### PR DESCRIPTION
Hello, @willdurand.
I would like to see the behavior as described in the documentation: https://github.com/willdurand/EmailReplyParser/blob/master/README.md#weird-signatures

I was faced with the fact that the signature is defined incorrectly. The line with "--" or "__" in the middle of the string is not signature.

Let's fix the situation.
