### PR TITLE
Added late static binding support

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -148,12 +148,12 @@ class EmailParser
 
     private function isSignature($line)
     {
-        return preg_match(self::SIG_REGEX, $line) ? true : false;
+        return preg_match(static::SIG_REGEX, $line) ? true : false;
     }
 
     private function isQuote($line)
     {
-        return preg_match(self::QUOTE_REGEX, $line) ? true : false;
+        return preg_match(static::QUOTE_REGEX, $line) ? true : false;
     }
 
     private function isEmpty(FragmentDTO $fragment)


### PR DESCRIPTION
Hi William,

Thanks for porting this to PHP! We've just started using your little library, but the results so far look promising. I've prepared a small pull request which replaces all `self::` calls with `static::`.

I did this so I could subclass the `EmailParser` class and add my own `SIG_REGEX` const, which I've extended with some localized signature strings (f.e. 'Met vriendelijke groet' (with kind regards) and 'Verstuurd vanaf mijn iPhone' (Sent from my iPhone)).

Hope you will pull this in!

-b
