### PR TITLE
Switched to the preinstalled composer version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
     - 5.5
 
 before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar --dev install
+    - composer install
 
 script: phpunit --coverage-text


### PR DESCRIPTION
This avoids downloading composer each time. Given that we only rely on composer to create the autoloader (there is no dependencies), it is fine even when the Travis version is a bit old rather than having the nightly build.
