### PR TITLE
Update readme with latest Composer tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,9 @@ Installation
 The recommended way to install EmailReplyParser is through
 [Composer](http://getcomposer.org/):
 
-``` json
-{
-    "require": {
-        "willdurand/email-reply-parser": "@stable"
-    }
-}
+``` shell
+composer require willdurand/email-reply-parser
 ```
-
-**Protip:** you should browse the
-[`willdurand/email-reply-parser`](https://packagist.org/packages/willdurand/email-reply-parser)
-page to choose a stable version to use, avoid the `@stable` meta constraint.
-
 
 Usage
 -----


### PR DESCRIPTION
1. `composer install --dev` is the default for some time now and the `--dev` flag is deprecated.
2. `Composer 1.0.0-alpha.9` comes with an important update to `composer require`. When you don't specify a version, Composer would automatically choose the latest stable version according to SemVer.
