### PR TITLE
Use PSR-4 and autoload-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Unit Tests
 
 Setup the test suite using Composer:
 
-    $ composer install --dev
+    $ composer install
 
 Run it using PHPUnit:
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "psr-0": { "EmailReplyParser": "src/" }
+        "psr-4": { "EmailReplyParser\\": "src/EmailReplyParser" }
+    },
+    "autoload-dev": {
+        "psr-4": { "EmailReplyParser\\Tests\\": "tests/EmailReplyParser/Tests" }
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
     processIsolation="false"
     stopOnFailure="false"
     syntaxCheck="false"
-    bootstrap="tests/bootstrap.php"
+    bootstrap="vendor/autoload.php"
     >
     <testsuites>
         <testsuite name="EmailReplyParser Test Suite">

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Simple autoloader that follow the PHP Standards Recommendation #0 (PSR-0)
- * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md for more informations.
+ * Simple autoloader that follow the PHP Standards Recommendation #4 (PSR-4)
+ * @see https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md for more informations.
  *
  * Code inspired from the SplClassLoader RFC
  * @see https://wiki.php.net/rfc/splclassloader#example_implementation

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-$loader = require_once __DIR__ . '/../vendor/autoload.php';
-$loader->add('EmailReplyParser\Tests', __DIR__);


### PR DESCRIPTION
- PSR-4 is the successor of PSR-0. PSR-0 is deprecated now.
  The provided autoloader does not respect the underscore rule from PSR-0 anyway.
- `autoload-dev` is a feature of Composer to dump additional namespaces in the autoloader
  when dev dependencies are being installed. This way there is no need to have a separate bootstrap file for PHPUnit.