### PR TITLE
Find signatures with no empty line above

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -66,7 +66,7 @@ class EmailParser
                 $line = ltrim($line);
             }
 
-            if ($fragment && empty($line)) {
+            if ($fragment) {
                 $last = end($fragment->lines);
 
                 if ($this->isSignature($last)) {
@@ -74,7 +74,7 @@ class EmailParser
                     $this->addFragment($fragment);
 
                     $fragment = null;
-                } elseif ($this->isQuoteHeader($last)) {
+                } elseif (empty($line) && $this->isQuoteHeader($last)) {
                     $fragment->isQuoted = true;
                     $this->addFragment($fragment);
 

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -166,10 +166,51 @@ EMAIL
         $this->assertRegExp('/^--\nrick/', (string) $fragments[1]);
     }
 
+    public function testReadsEmailWithSignatureWithNoEmptyLineAbove()
+    {
+        $email     = $this->parser->parse($this->getFixtures('sig_no_empty_line.txt'));
+        $fragments = $email->getFragments();
+
+        $this->assertCount(2, $fragments);
+
+        $this->assertFalse($fragments[0]->isQuoted());
+        $this->assertFalse($fragments[1]->isQuoted());
+
+        $this->assertFalse($fragments[0]->isSignature());
+        $this->assertTrue($fragments[1]->isSignature());
+
+        $this->assertFalse($fragments[0]->isHidden());
+        $this->assertTrue($fragments[1]->isHidden());
+
+        $this->assertRegExp('/^--\nrick/', (string) $fragments[1]);
+    }
+
     public function testReadsEmailWithCorrectSignatureWithSpace()
     {
         // A common convention is to use "-- " as delimitor, but trailing spaces are often stripped by IDEs, so add them here
         $content = str_replace('--', '-- ', $this->getFixtures('correct_sig.txt'));
+
+        $email     = $this->parser->parse($content);
+        $fragments = $email->getFragments();
+
+        $this->assertCount(2, $fragments);
+
+        $this->assertFalse($fragments[0]->isQuoted());
+        $this->assertFalse($fragments[1]->isQuoted());
+
+        $this->assertFalse($fragments[0]->isSignature());
+        $this->assertTrue($fragments[1]->isSignature());
+
+        $this->assertFalse($fragments[0]->isHidden());
+        $this->assertTrue($fragments[1]->isHidden());
+
+        $this->assertRegExp('/^-- \nrick/', (string) $fragments[1]);
+    }
+
+    public function testReadsEmailWithCorrectSignatureWithNoEmptyLineWithSpace()
+    {
+        // A common convention is to use "-- " as delimitor, but trailing spaces are often stripped by IDEs, so add them here
+        $content = str_replace('--', '-- ', $this->getFixtures('sig_no_empty_line.txt'));
 
         $email     = $this->parser->parse($content);
         $fragments = $email->getFragments();

--- a/tests/Fixtures/sig_no_empty_line.txt
+++ b/tests/Fixtures/sig_no_empty_line.txt
@@ -1,0 +1,3 @@
+this is an email with a signature with no empty line above.
+--
+rick


### PR DESCRIPTION
GMail Inbox is creating such signatures by default.

Specifically in my case I had this kind of text passed to the parser:

```
Thanks,
Harry
-- 
Haralan Dobrev
http://hkdobrev.com
```

This is the text of the email as it came from Inbox. In my signature settings I have only entered the last two lines. It adds the dashes by itself with no extra newline character.