### PR TITLE
Update EmailParser.php

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -21,7 +21,7 @@ class EmailParser
     /**
      * Regex to match signatures
      */
-    const SIG_REGEX   = '/(?:^\s*--|^\s*__|^-\w|^-- )|(?:^Sent from my (?:\s*\w+){1,3})$/s';
+    const SIG_REGEX   = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from my (?:\s*\w+){1,3})$/s';
 
     const QUOTE_REGEX = '/>+$/s';
 


### PR DESCRIPTION
fix usenet official signature: `^-- \n`
https://en.wikipedia.org/wiki/Signature_block#Signatures_in_Usenet_postings

as per comments:
https://github.com/willdurand/EmailReplyParser/pull/43#issuecomment-185304924
https://github.com/willdurand/EmailReplyParser/pull/43#issuecomment-185595902

and
https://github.com/willdurand/EmailReplyParser/pull/42#issuecomment-184572560