### PR TITLE
Update EmailParser.php Regex to include Outlook

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -36,6 +36,7 @@ class EmailParser
         '/^(Den\s.+\sskrev\s.+:)$/m', // Den DATE skrev NAME <EMAIL>:
         '/^(Am\s.+\sum\s.+\sschrieb\s.+:)$/m', // Am DATE um TIME schrieb NAME:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
+        '/^(From.+$)/m', // From NAME <EMAIL> schrieb:
         '/^(20[0-9]{2}\-(?:0?[1-9]|1[012])\-(?:0?[0-9]|[1-2][0-9]|3[01]|[1-9])\s[0-2]?[0-9]:\d{2}\s.+?:)$/ms', // 20YY-MM-DD HH:II GMT+01:00 NAME <EMAIL>:
     );
 


### PR DESCRIPTION
Added Regex to include From tag as a quote header break.

Included a regex tester:
https://regex101.com/r/gI4kD8/2

This make it compatible with Outlook 2016 for OSX
