### PR TITLE
Fix some quote header regex to make it less greedy

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -29,11 +29,11 @@ class EmailParser
      * @var string[]
      */
     private $quoteHeadersRegex = array(
-        '/^\s*(On\s.+?wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
-        '/^\s*(Le\s.+?écrit :)$/ms', // Le DATE, NAME <EMAIL> a écrit :
-        '/^\s*(El\s.+?escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:
-        '/^\s*(Il\s.+?scritto:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
-        '/^\s*(Op\s.+?schreef.+:)$/ms', // Il DATE, schreef NAME <EMAIL>:
+        '/^\s*(?!On.*^\s*On\s.+?wrote:)(On\s.+?wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
+        '/^\s*(?!Le.*^\s*Le\s.+?écrit :)(Le\s.+?écrit :)$/ms', // Le DATE, NAME <EMAIL> a écrit :
+        '/^\s*(?!El.*^\s*El\s.+?escribió:)(El\s.+?escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:
+        '/^\s*(?!Il.*^\s*Il\s.+?scritto:)(Il\s.+?scritto:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
+        '/^\s*(?!Op.*^\s*Op\s.+?schreef.+:)(Op\s.+?schreef.+:)$/ms', // Il DATE, schreef NAME <EMAIL>:
         '/^\s*((W\sdniu|Dnia)\s.+?(pisze|napisał(\(a\))?):)$/msu', // W dniu DATE, NAME <EMAIL> pisze|napisał:
         '/^\s*(Den\s.+\sskrev\s.+:)$/m', // Den DATE skrev NAME <EMAIL>:
         '/^\s*(Am\s.+\sum\s.+\sschrieb\s.+:)$/m', // Am DATE um TIME schrieb NAME:

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -138,7 +138,7 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_6.txt'));
         $fragments = $email->getFragments();
 
-        $this->assertRegExp('/^I get/', (string) $fragments[0]);
+        $this->assertRegExp('/^On average/', (string) $fragments[0]);
         $this->assertRegExp('/^On/', (string) $fragments[1]);
         $this->assertRegExp('/Was this/', (string) $fragments[1]);
     }

--- a/tests/Fixtures/email_6.txt
+++ b/tests/Fixtures/email_6.txt
@@ -1,4 +1,4 @@
-I get proper rendering as well.
+On average, I get proper rendering.
 
 Sent from a magnificent torch of pixels
 


### PR DESCRIPTION
Hello,

The quote header regexes, while ungreedy, caugth too much text. The problem occure when you deal with this kind of email:
```
Hello,

On sunday, I will be on the Moon.

On Nov 21, 2014, at 10:18, Pikachu <pickachu@example.com> wrote:

> Hi John,
> Where will you be on end of the week?
```

With the old regex, the quote header was `On sunday(...)wrote` , with the new one, its `On Nov 21(...)wrote`.

While we don't deal with astronaut and Pokemons (At the moment!), we will be glad to consider this fix ;)