### PR TITLE
Fix test suite to be run in PHP5 and PHP7 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: php
+language: php
+sudo: required
+dist: trusty
+group: edge
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
-    - hhvm
+    - 7.1
+    - hhvm-3.9
+    - hhvm-3.18
 
 before_script:
     - composer install
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "willdurand/email-reply-parser",
     "type": "library",
-    "description": "Port of the cool GitHub's EmailReplyParser library in PHP 5.3",
+    "description": "Port of the cool GitHub's EmailReplyParser library in PHP",
     "keywords": ["email", "reply-parser"],
     "license": "MIT",
     "authors": [
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0"
     },
     "autoload": {
         "psr-4": { "EmailReplyParser\\": "src/EmailReplyParser" }
@@ -23,5 +23,8 @@
         "branch-alias": {
             "dev-master": "2.5-dev"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.35|^5.7"
     }
 }

--- a/tests/EmailReplyParser/Tests/TestCase.php
+++ b/tests/EmailReplyParser/Tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace EmailReplyParser\Tests;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @param string $file


### PR DESCRIPTION
Add a compatibility layer to be able to run the test suite in PHP5 or PHP7 env. This will fix Travis builds.