### PR TITLE
Fix from quote headers regexes

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -41,10 +41,10 @@ class EmailParser
         '/^(20[0-9]{2}\..+\s작성:)$/m', // DATE TIME NAME 작성:
         '/^(20[0-9]{2}\/.+のメッセージ:)$/m', // DATE TIME、NAME のメッセージ:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
-        '/^\s*(From\s?:.+\s?([|<).+(]|>))/su', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
-        '/^\s*(De\s?:.+\s?([|<).+(]|>))/su', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With support whitespace before start and before <)
-        '/^\s*(Van\s?:.+\s?([|<).+(]|>))/su', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <)
-        '/^\s*(Da\s?:.+\s?([|<).+(]|>))/su', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <)
+        '/^\s*(From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
+        '/^\s*(De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With support whitespace before start and before <)
+        '/^\s*(Van\s?:.+\s?(\[|<).+(\]|>))/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <)
+        '/^\s*(Da\s?:.+\s?(\[|<).+(\]|>))/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <)
         '/^(20[0-9]{2}\-(?:0?[1-9]|1[012])\-(?:0?[0-9]|[1-2][0-9]|3[01]|[1-9])\s[0-2]?[0-9]:\d{2}\s.+?:)$/ms', // 20YY-MM-DD HH:II GMT+01:00 NAME <EMAIL>:
         '/^\s*([a-z]{3,4}\.\s.+\sskrev\s.+:)$/ms', // DATE skrev NAME <EMAIL>:
     );

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -449,4 +449,29 @@ merci d'avance", $email->getVisibleText());
             array("tir. 18. apr. 2017 kl. 13:09 skrev Test user <test@example.com>:"), // Norwegian Gmail
         );
     }
+
+    /**
+     * @dataProvider getFromHeaders
+     */
+    public function testFromQuoteHeader($from)
+    {
+        $email = $this->parser->parse(str_replace('[FROM]', $from, $this->getFixtures('email_with_from_headers.txt')));
+        $fragments = $email->getFragments();
+        $this->assertSame(<<<CONTENT
+{$from}
+
+My email is <foo@example.com>
+CONTENT
+        , $fragments[1]->getContent());
+    }
+
+    public function getFromHeaders()
+    {
+        return array(
+            array('From: foo@example.com <foo@example.com>'),
+            array('De: foo@example.com <foo@example.com>'),
+            array('Van: foo@example.com <foo@example.com>'),
+            array('Da: foo@example.com <foo@example.com>'),
+        );
+    }
 }

--- a/tests/Fixtures/email_with_from_headers.txt
+++ b/tests/Fixtures/email_with_from_headers.txt
@@ -1,0 +1,4 @@
+
+[FROM]
+
+My email is <foo@example.com>


### PR DESCRIPTION
This fix two things for "From:" quote headers.

## Improve regex for edge case

We had to handle this kind of weird email (note that the begining of the content are newlines):
```

From: foo <foo@example.com>

My email is <foo@example.com>
```
We the actual regex, this lead to messup the content of the second fragment, instead of getting:
```
From: foo <foo@example.com>

My email is <foo@example.com>
```
we get 
```
From: foo <foo@example.com> My email is <foo@example.com>
```

ATM, a simple solution is to consider that this kind of header cannot span over multiple lines. This is the solution we offer in this PR.

## Fix escaping of '['**

Working on this fix we encounter a case that caught up to our eye that an escaping was missing.