### PR TITLE
Parse email with simplified chinese headers

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -42,6 +42,7 @@ class EmailParser
         '/^(20[0-9]{2}\/.+のメッセージ:)$/m', // DATE TIME、NAME のメッセージ:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
         '/^\s*(From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
+        '/^\s*(发件人\s?:.+\s?(\[|<).+(\]|>))/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With support whitespace before start and before <)
         '/^\s*(De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With support whitespace before start and before <)
         '/^\s*(Van\s?:.+\s?(\[|<).+(\]|>))/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <)
         '/^\s*(Da\s?:.+\s?(\[|<).+(\]|>))/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <)

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -148,7 +148,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_7.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailDutch()
@@ -156,7 +155,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_8.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailSignatureWithEqual()
@@ -164,7 +162,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_9.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailHotmail()
@@ -172,7 +169,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_10.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailWhitespaceBeforeHeader()
@@ -180,7 +176,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_11.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailWithSquareBrackets()
@@ -188,7 +183,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_12.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailDaIntoItalian()
@@ -196,7 +190,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_13.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailHeaderPolish()
@@ -204,7 +197,13 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_14.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
+    }
 
+    public function testEmailHeaderSimplifiedChinese()
+    {
+        $email     = $this->parser->parse($this->getFixtures('email_22.txt'));
+        $fragments = $email->getFragments();
+        $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
     }
 
     public function testEmailSentFromMy()
@@ -212,7 +211,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_15.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailHeaderPolishWithDniaAndNapisala()
@@ -220,7 +218,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_16.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailHeaderPolishWithDateInIso8601()
@@ -228,7 +225,6 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_17.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
 
     public function testEmailOutlookEn()
@@ -236,9 +232,7 @@ EMAIL
         $email     = $this->parser->parse($this->getFixtures('email_18.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
-
     }
-
 
     public function testGetVisibleTextReturnsOnlyVisibleFragments()
     {
@@ -250,14 +244,12 @@ EMAIL
         $this->assertEquals(rtrim(implode("\n", $visibleFragments)), $email->getVisibleText());
     }
 
-
     public function testEmailGmailNo()
     {
         $email     = $this->parser->parse($this->getFixtures('email_norwegian_gmail.txt'));
         $fragments = $email->getFragments();
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
     }
-
 
     public function testReadsEmailWithCorrectSignature()
     {

--- a/tests/Fixtures/email_22.txt
+++ b/tests/Fixtures/email_22.txt
@@ -1,0 +1,14 @@
+Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
+Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
+Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
+et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
+
+发件人: Company Questions <questions@company.com>
+发送时间: 2017年8月2日 15:37
+收件人: Sylvie
+主题: Company France - China
+
+Etiam non sagittis orci, non rutrum urna. Suspendisse ut sapien id dolor posuere placerat et vitae felis.
+Fusce mollis condimentum nulla. Donec luctus justo eu purus placerat, non suscipit ex facilisis.
+Sed risus lorem, porta eget imperdiet in, euismod eu nisl. Integer vel metus felis.


### PR DESCRIPTION
It allows to parse email that contains simplified chinese headers in content (The same logic as italian, polish and frensh headers).

- [x] Run test suite
- [x] Update unit test
