### PR TITLE
The russian quoteHeadersRegex should not check for "wrote:"

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -35,7 +35,7 @@ class EmailParser
         '/^\s*(Le(?:(?!^>*\s*Le\b|\bécrit:).){0,1000}écrit :)$/ms', // Le DATE, NAME <EMAIL> a écrit :
         '/^\s*(El(?:(?!^>*\s*El\b|\bescribió:).){0,1000}escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:
         '/^\s*(Il(?:(?!^>*\s*Il\b|\bscritto:).){0,1000}scritto:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
-        '/^[\S\s]+ (написа(л|ла|в)+|wrote)+:/msu', // Everything before написал:
+        '/^[\S\s]+ (написа(л|ла|в)+)+:$/msu', // Everything before написал: not ending on wrote:
         '/^\s*(Op\s.+?schreef.+:)$/ms', // Il DATE, schreef NAME <EMAIL>:
         '/^\s*((W\sdniu|Dnia)\s.+?(pisze|napisał(\(a\))?):)$/msu', // W dniu DATE, NAME <EMAIL> pisze|napisał:
         '/^\s*(Den\s.+\sskrev\s.+:)$/m', // Den DATE skrev NAME <EMAIL>:

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -161,6 +161,7 @@ EMAIL
     {
         $email     = $this->parser->parse($this->getFixtures('email_23.txt'));
         $fragments = $email->getFragments();
+        $fragments[0] = str_replace("\nSomebody wrote:\n", '', $fragments[0]);
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
     }
 

--- a/tests/Fixtures/email_23.txt
+++ b/tests/Fixtures/email_23.txt
@@ -1,6 +1,8 @@
 Fusce bibendum, quam hendrerit sagittis tempor, dui turpis tempus erat, pharetra sodales ante sem sit amet metus.
 Nulla malesuada, orci non vulputate lobortis, massa felis pharetra ex, convallis consectetur ex libero eget ante.
 Nam vel turpis posuere, rhoncus ligula in, venenatis orci. Duis interdum venenatis ex a rutrum.
+
+Somebody wrote:
 Duis ut libero eu lectus consequat consequat ut vel lorem. Vestibulum convallis lectus urna,
 et mollis ligula rutrum quis. Fusce sed odio id arcu varius aliquet nec nec nibh.
 


### PR DESCRIPTION
The Ukrainian regex checks for "wrote:" causing it to accept "Somebody wrote:" as a header line for a reply. Believe wrote should already be covered in the other regex's.

I adjusted the Ukrainian test case to have wrote in the text so that it would fail with the old regex, not with the new one.

Since this is very specific i had to modify the case and add a tiny cleanup code so that travis would properly fail or pass the adjustments