### PR TITLE
Additional signature and quote catches

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -93,7 +93,7 @@ class EmailParser
                     $this->addFragment($fragment);
 
                     $fragment = null;
-                } elseif (empty($line) && $this->isQuoteHeader($first)) {
+                } elseif ($this->isQuoteHeader($first)) {
                     $fragment->isQuoted = true;
                     $this->addFragment($fragment);
 

--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -31,6 +31,7 @@ class EmailParser
      * @var string[]
      */
     private $quoteHeadersRegex = array(
+        '/^\s*In a message dated .{8,1000} (writes|wrote):$/ms', // In a message dated DATE EMAIL writes/wrote:
         '/^\s*(On(?:(?!^>*\s*On\b|\bwrote:).){0,1000}wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
         '/^\s*(Le(?:(?!^>*\s*Le\b|\bécrit:).){0,1000}écrit :)$/ms', // Le DATE, NAME <EMAIL> a écrit :
         '/^\s*(El(?:(?!^>*\s*El\b|\bescribió:).){0,1000}escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:

--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -25,7 +25,7 @@ class EmailParser
      *
      * @var string
      */
-    private $signatureRegex = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from my (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s';
+    private $signatureRegex = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from (?:\s*\w+){1,5}$)|(?:^={30,}$)$/s';
 
     /**
      * @var string[]
@@ -44,6 +44,7 @@ class EmailParser
         '/^(20[0-9]{2}\..+\s작성:)$/m', // DATE TIME NAME 작성:
         '/^(20[0-9]{2}\/.+のメッセージ:)$/m', // DATE TIME、NAME のメッセージ:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
+        '/^\s*(From\s?:.+\s?)/mui', // FROM: NAME, From: Name
         '/^\s*(From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
         '/^\s*(发件人\s?:.+\s?(\[|<).+(\]|>))/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With support whitespace before start and before <)
         '/^\s*(De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With support whitespace before start and before <)


### PR DESCRIPTION
Catches signature and quotes for Windows 10 Mail.

I've probably made this too generalized, but I needed to catch signature and quotes coming from Mail for Windows 10. They look like this...

```
My reply here.

Sent from Mail for Windows 10

From: John Doe
Sent: Tuesday, November 13, 2018 12:30 PM
To: me@here.com
Cc: me@gmail.com
Subject: Subject Line Here

The quoted message.
```

Unfortunately, the existing regex's miss both the signature and the quote. The signature is missed because it lacks a "my" after "Sent from", so I just went ahead and removed the "my" requirement. The quote is missed because the "From:" line only includes a name and lacks an email address in brackets. I loosened it up to only bother checking for a line beginning with "From:".

This is probably related to Issue #66. I haven't run the unit tests, and I'm pretty sure these fixes loosen things up too much, so not exactly suggesting this be merged in as-is. Hoping someone better at regex's comes up with a more proper fix, honestly :)