### PR TITLE
Add support for getting visible reply text from Windows 10 Mail messages

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -25,7 +25,7 @@ class EmailParser
      *
      * @var string
      */
-    private $signatureRegex = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from my (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s';
+    private $signatureRegex = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from (my|Mail) (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s';
 
     /**
      * @var string[]

--- a/tests/EmailReplyParser/Tests/EmailReplyParserTest.php
+++ b/tests/EmailReplyParser/Tests/EmailReplyParserTest.php
@@ -72,6 +72,13 @@ EMAIL
         $this->assertEquals('Here is another email', EmailReplyParser::parseReply($body));
     }
 
+    public function testParseOutSentFromMailForWindows10()
+    {
+        $body = $this->getFixtures('email_w10_mail.txt');
+
+        $this->assertEquals("Great thanks Bort, going for a test now.\nBraxton", EmailReplyParser::parseReply($body));
+    }
+
     public function testParseOutSendFromMultiwordMobileDevice()
     {
         $body = $this->getFixtures('email_multi_word_sent_from_my_mobile_device.txt');

--- a/tests/Fixtures/email_w10_mail.txt
+++ b/tests/Fixtures/email_w10_mail.txt
@@ -1,0 +1,16 @@
+Great thanks Bort, going for a test now.
+Braxton
+
+Sent from Mail for Windows 10
+
+From: Bort
+Sent: April 9, 2020 2:02 PM
+To: braxton@company.com
+Subject: Re: [#000] Stuff pls
+
+Tickets
+[#000] Stuff pls
+Bort replied:
+Here is the stuff.
+In case you are wondering about that other stuff - we don't do that.
+Thanks!


### PR DESCRIPTION
I've added a sample sanitized email sent by Windows 10 Mail. The `From:` header really does look like that (no email address). I haven't changed handling of the `From:` address, just email text.

Inspired by #68 