### PR TITLE
Fix regexp to handle datetime lines starting wih a few characters before `On...`

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -32,7 +32,7 @@ class EmailParser
      */
     private $quoteHeadersRegex = array(
         '/^\s*(On(?:(?!^>*\s*On\b|\bwrote:).){0,1000}wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
-        '/^\s*(Le(?:(?!^>*\s*Le\b|\bécrit:).){0,1000}écrit(\s|\xc2\xa0):)$/ms', // Le DATE, NAME <EMAIL> a écrit :
+        '/^.{0,5}(Le\b(?:(?!^>*\s*Le\b|\bécrit(\s|\xc2\xa0)?:).){0,1000}écrit(\s|\xc2\xa0)?:)$/m', // Le DATE, NAME <EMAIL> a écrit :
         '/^\s*(El(?:(?!^>*\s*El\b|\bescribió:).){0,1000}escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:
         '/^\s*(Il(?:(?!^>*\s*Il\b|\bscritto:).){0,1000}scritto:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
         '/^[\S\s]+ (написа(л|ла|в)+)+:$/msu', // Everything before написал: not ending on wrote:

--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -31,10 +31,10 @@ class EmailParser
      * @var string[]
      */
     private $quoteHeadersRegex = array(
-        '/^\s*(On(?:(?!^>*\s*On\b|\bwrote:).){0,1000}wrote:)$/ms', // On DATE, NAME <EMAIL> wrote:
-        '/^.{0,5}(Le\b(?:(?!^>*\s*Le\b|\bécrit(\s|\xc2\xa0)?:).){0,1000}écrit(\s|\xc2\xa0)?:)$/m', // Le DATE, NAME <EMAIL> a écrit :
-        '/^\s*(El(?:(?!^>*\s*El\b|\bescribió:).){0,1000}escribió:)$/ms', // El DATE, NAME <EMAIL> escribió:
-        '/^\s*(Il(?:(?!^>*\s*Il\b|\bscritto:).){0,1000}scritto:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
+        '/^.{0,5}(On(?:(?!\bOn\b|\bwrote(\s|\xc2\xa0)?:).){0,1000}wrote(\s|\xc2\xa0)?:)$/ms', // On DATE, NAME <EMAIL> wrote:
+        '/^.{0,5}(Le\b(?:(?!\bLe\b|\bécrit(\s|\xc2\xa0)?:).){0,1000}écrit(\s|\xc2\xa0)?:)$/ms', // Le DATE, NAME <EMAIL> a écrit :
+        '/^.{0,5}(El(?:(?!\bEl\b|\bescribió\s?:).){0,1000}escribió\s?:)$/ms', // El DATE, NAME <EMAIL> escribió:
+        '/^.{0,5}(Il(?:(?!\bIl\b|\bscritto(\s|\xc2\xa0)?:).){0,1000}scritto(\s|\xc2\xa0)?:)$/ms', // Il DATE, NAME <EMAIL> ha scritto:
         '/^[\S\s]+ (написа(л|ла|в)+)+:$/msu', // Everything before написал: not ending on wrote:
         '/^\s*(Op\s.+?(schreef|geschreven).+:)$/ms', // Op DATE schreef NAME <EMAIL>:, Op DATE heeft NAME <EMAIL> het volgende geschreven:
         '/^\s*((W\sdniu|Dnia)\s.+?(pisze|napisał(\(a\))?):)$/msu', // W dniu DATE, NAME <EMAIL> pisze|napisał:

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -273,13 +273,21 @@ EMAIL
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
     }
 
-    public function testEmailFreeZimbra()
+    public function testEmailFreeZimbraFr()
     {
         $email     = $this->parser->parse($this->getFixtures('email_zimbra_free_fr.txt'));
         $fragments = $email->getFragments();
         $this->assertStringContainsString('Michael Scott', $fragments[0]);
         $this->assertStringNotContainsString('Toby Flenderson', $fragments[0]);
     }
+
+    /*public function testEmailFreeZimbraEn()
+    {
+        $email     = $this->parser->parse($this->getFixtures('email_zimbra_free_en.txt'));
+        $fragments = $email->getFragments();
+        $this->assertStringContainsString('Michael Scott', $fragments[0]);
+        $this->assertStringNotContainsString('Toby Flenderson', $fragments[0]);
+    }*/
 
     public function testReadsEmailWithCorrectSignature()
     {

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -281,13 +281,13 @@ EMAIL
         $this->assertStringNotContainsString('Toby Flenderson', $fragments[0]);
     }
 
-    /*public function testEmailFreeZimbraEn()
+    public function testEmailFreeZimbraEn()
     {
         $email     = $this->parser->parse($this->getFixtures('email_zimbra_free_en.txt'));
         $fragments = $email->getFragments();
         $this->assertStringContainsString('Michael Scott', $fragments[0]);
         $this->assertStringNotContainsString('Toby Flenderson', $fragments[0]);
-    }*/
+    }
 
     public function testReadsEmailWithCorrectSignature()
     {

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -297,7 +297,7 @@ EMAIL
         $this->assertFalse($fragments[0]->isHidden());
         $this->assertTrue($fragments[1]->isHidden());
 
-        $this->assertStringContains('/^--\nrick/', (string) $fragments[1]);
+        $this->assertMatchesRegularExpression('/^--\nrick/', (string) $fragments[1]);
     }
 
     public function testReadsEmailWithSignatureWithNoEmptyLineAbove()

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -273,6 +273,14 @@ EMAIL
         $this->assertEquals(static::COMMON_FIRST_FRAGMENT, trim($fragments[0]));
     }
 
+    public function testEmailFreeZimbra()
+    {
+        $email     = $this->parser->parse($this->getFixtures('email_zimbra_free_fr.txt'));
+        $fragments = $email->getFragments();
+        $this->assertStringContainsString('Michael Scott', $fragments[0]);
+        $this->assertStringNotContainsString('Toby Flenderson', $fragments[0]);
+    }
+
     public function testReadsEmailWithCorrectSignature()
     {
         $email     = $this->parser->parse($this->getFixtures('correct_sig.txt'));
@@ -289,7 +297,7 @@ EMAIL
         $this->assertFalse($fragments[0]->isHidden());
         $this->assertTrue($fragments[1]->isHidden());
 
-        $this->assertMatchesRegularExpression('/^--\nrick/', (string) $fragments[1]);
+        $this->assertStringContains('/^--\nrick/', (string) $fragments[1]);
     }
 
     public function testReadsEmailWithSignatureWithNoEmptyLineAbove()

--- a/tests/Fixtures/email_zimbra_free_en.txt
+++ b/tests/Fixtures/email_zimbra_free_en.txt
@@ -1,17 +1,16 @@
-Bonjour ​Test​,
+Bonjour Toby,
 
 ​Text paragraph 1​
 
-
-Le paragraphe qui pose problème.
+On this line is the issue
 
 ​Text paragraph 2​
 
 Michael Scott
 
-- Le 2021-04-09 23:25, Dwight Schrute a écrit :
+- On 2021-04-09 23:25, Toby Flenderson a wrote:
 > [1]
 >
->  BONJOUR TEST,
+>  BONJOUR Mike,
 >
 >  Vous venez de recevoir un message. Le visiteur vous l'envoie depuis:

--- a/tests/Fixtures/email_zimbra_free_fr.txt
+++ b/tests/Fixtures/email_zimbra_free_fr.txt
@@ -1,0 +1,17 @@
+Bonjour Toby,
+
+​Text paragraph 1​
+
+
+Le paragraphe qui pose problème.
+
+​Text paragraph 2​
+
+Michael Scott
+
+- Le 2021-04-09 23:25, Toby Flenderson a écrit :
+> [1]
+>
+>  BONJOUR Mike,
+>
+>  Vous venez de recevoir un message. Le visiteur vous l'envoie depuis:

--- a/tests/Fixtures/email_zimbra_free_fr.txt
+++ b/tests/Fixtures/email_zimbra_free_fr.txt
@@ -9,7 +9,7 @@ Le paragraphe qui pose problème.
 
 Michael Scott
 
-- Le 2021-04-09 23:25, Dwight Schrute a écrit :
+- Le 2021-04-09 23:25, Toby Flenderson a écrit :
 > [1]
 >
 >  BONJOUR TEST,


### PR DESCRIPTION
This fixes #77 

The rule is more permissive for prefixes, however more strict and secure as I disabled the `s` modifier which allowed multiline for some reason.

Important Note : I only fixed FR. I prepared (commented) a failing test for EN, which failed. But if I do the same change for EN regexp, other tests are failing and I don't want to mess up things, so I'll let you have a look at this.