### PR TITLE
Handle O365 Outlook replies

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -45,11 +45,11 @@ class EmailParser
         '/^(20[0-9]{2}\..+\s작성:)$/m', // DATE TIME NAME 작성:
         '/^(20[0-9]{2}\/.+のメッセージ:)$/m', // DATE TIME、NAME のメッセージ:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
-        '/^\s*([\*]{0,2}From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <EMAIL>, and optional ** before 'From')
-        '/^\s*([\*]{0,2}发件人\s?:.+\s?(\[|<).+(\]|>))/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With support whitespace before start and before <EMAIL>, and optional ** before '发件人')
-        '/^\s*([\*]{0,2}De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'De')
-        '/^\s*([\*]{0,2}Van\s?:.+\s?(\[|<).+(\]|>))/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <EMAIL>, and optional ** before 'Van')
-        '/^\s*([\*]{0,2}Da\s?:.+\s?(\[|<).+(\]|>))/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <EMAIL>, and optional ** before 'Da')
+        '/^\s*([\*]{0,2}From\s?:.+\s?[(\[|<).+(\]|>)]?)/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'From')
+        '/^\s*([\*]{0,2}发件人\s?:.+\s?[(\[|<).+(\]|>)]?)/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before '发件人')
+        '/^\s*([\*]{0,2}De\s?:.+\s?[(\[|<).+(\]|>)]?)/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'De')
+        '/^\s*([\*]{0,2}Van\s?:.+\s?[(\[|<).+(\]|>)]?)/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'Van')
+        '/^\s*([\*]{0,2}Da\s?:.+\s?[(\[|<).+(\]|>)]?)/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'Da')
         '/^(20[0-9]{2}\-(?:0?[1-9]|1[012])\-(?:0?[0-9]|[1-2][0-9]|3[01]|[1-9])\s[0-2]?[0-9]:\d{2}\s.+?:)$/ms', // 20YY-MM-DD HH:II GMT+01:00 NAME <EMAIL>:
         '/^\s*([a-z]{3,4}\.\s.+\sskrev\s.+:)$/ms', // DATE skrev NAME <EMAIL>:
     );

--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -45,11 +45,11 @@ class EmailParser
         '/^(20[0-9]{2}\..+\s작성:)$/m', // DATE TIME NAME 작성:
         '/^(20[0-9]{2}\/.+のメッセージ:)$/m', // DATE TIME、NAME のメッセージ:
         '/^(.+\s<.+>\sschrieb:)$/m', // NAME <EMAIL> schrieb:
-        '/^\s*(From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <)
-        '/^\s*(发件人\s?:.+\s?(\[|<).+(\]|>))/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With support whitespace before start and before <)
-        '/^\s*(De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With support whitespace before start and before <)
-        '/^\s*(Van\s?:.+\s?(\[|<).+(\]|>))/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <)
-        '/^\s*(Da\s?:.+\s?(\[|<).+(\]|>))/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <)
+        '/^\s*([\*]{0,2}From\s?:.+\s?(\[|<).+(\]|>))/mu', // "From: NAME <EMAIL>" OR "From : NAME <EMAIL>" OR "From : NAME<EMAIL>"(With support whitespace before start and before <EMAIL>, and optional ** before 'From')
+        '/^\s*([\*]{0,2}发件人\s?:.+\s?(\[|<).+(\]|>))/mu', // "发件人: NAME <EMAIL>" OR "发件人 : NAME <EMAIL>" OR "发件人 : NAME<EMAIL>"(With support whitespace before start and before <EMAIL>, and optional ** before '发件人')
+        '/^\s*([\*]{0,2}De\s?:.+\s?(\[|<).+(\]|>))/mu', // "De: NAME <EMAIL>" OR "De : NAME <EMAIL>" OR "De : NAME<EMAIL>"  (With optional <EMAIL>, support whitespace before start and before <EMAIL>, and optional ** before 'De')
+        '/^\s*([\*]{0,2}Van\s?:.+\s?(\[|<).+(\]|>))/mu', // "Van: NAME <EMAIL>" OR "Van : NAME <EMAIL>" OR "Van : NAME<EMAIL>"  (With support whitespace before start and before <EMAIL>, and optional ** before 'Van')
+        '/^\s*([\*]{0,2}Da\s?:.+\s?(\[|<).+(\]|>))/mu', // "Da: NAME <EMAIL>" OR "Da : NAME <EMAIL>" OR "Da : NAME<EMAIL>"  (With support whitespace before start and before <EMAIL>, and optional ** before 'Da')
         '/^(20[0-9]{2}\-(?:0?[1-9]|1[012])\-(?:0?[0-9]|[1-2][0-9]|3[01]|[1-9])\s[0-2]?[0-9]:\d{2}\s.+?:)$/ms', // 20YY-MM-DD HH:II GMT+01:00 NAME <EMAIL>:
         '/^\s*([a-z]{3,4}\.\s.+\sskrev\s.+:)$/ms', // DATE skrev NAME <EMAIL>:
     );


### PR DESCRIPTION
Hello there !

While using a Mantis BT plugin which is using your awesome lib, I noticed the that the `<EMAIL>` is no longer present, and `From :` is prefixed with `**`, that's why I modified the according regex.

___

Outlook O365 replies are formatted as follows: 
```php
* * *

**From :** Firstname LASTNAME 

**Sent :** mardi 3 août 2021 18:41

**To :** Firstname LASTNAME ; Firstname LASTNAME 

**Object :** RE: Nouveau ticket par mail [0000051] 
```

___

I still have some questions to improve this PR
- Should I include `* * *` and the line-breaks to the regex (making them optional probably) ?
- Should I check for `**` **after** the `From :` ? (adding a second `[\*]{0,2}`)
- Should I replace `[\*]{0,2}` with `[\*]*` ? (So if Microsoft or another mailer decides to use more than two `*` it'll be handled)

___

**I didn't modified or ran the tests yet.**

Thanks in advance for your reviews !