### PR TITLE
Allow multiple signature regexes & add Dutch send from  my iPhone sig…

### DIFF
--- a/src/EmailReplyParser/Parser/EmailParser.php
+++ b/src/EmailReplyParser/Parser/EmailParser.php
@@ -25,7 +25,10 @@ class EmailParser
      *
      * @var string
      */
-    private $signatureRegex = '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from (my|Mail) (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s';
+    private $signatureRegex = [
+        '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Sent from (my|Mail) (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s',
+        '/(?:^\s*--|^\s*__|^-\w|^-- $)|(?:^Verstuurd vanaf mijn (?:\s*\w+){1,4}$)|(?:^={30,}$)$/s',
+    ];
 
     /**
      * @var string[]
@@ -151,7 +154,7 @@ class EmailParser
     }
 
     /**
-     * @return string
+     * @return string[]
      * @since 2.7.0
      */
     public function getSignatureRegex()
@@ -160,12 +163,12 @@ class EmailParser
     }
 
     /**
-     * @param string $signatureRegex
+     * @param string[] $signatureRegex
      *
      * @return EmailParser
      * @since 2.7.0
      */
-    public function setSignatureRegex($signatureRegex)
+    public function setSignatureRegex(array $signatureRegex)
     {
         $this->signatureRegex = $signatureRegex;
 
@@ -205,7 +208,13 @@ class EmailParser
 
     private function isSignature($line)
     {
-        return preg_match($this->signatureRegex, $line) ? true : false;
+        foreach ($this->signatureRegex as $regex) {
+            if (preg_match($regex, $line)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
+++ b/tests/EmailReplyParser/Tests/Parser/EmailParserTest.php
@@ -455,7 +455,10 @@ merci d'avance", $email->getVisibleText());
      */
     public function testCustomSignatureRegex()
     {
-        $signatureRegex = '/(?:^\s*--|^\s*__|^-- $)|(?:^Sent from my (?:\s*\w+){1,3})$/s';
+        $signatureRegex = [
+            '/^DOESNT_MATCH_ANYTHING$/',
+            '/(?:^\s*--|^\s*__|^-- $)|(?:^Sent from my (?:\s*\w+){1,3})$/s',
+        ];
         $this->parser->setSignatureRegex($signatureRegex);
         $email = $this->parser->parse($this->getFixtures('email_ls-l.txt'));
         $fragments = $email->getFragments();

--- a/tests/Fixtures/email_iphone_dutch.txt
+++ b/tests/Fixtures/email_iphone_dutch.txt
@@ -1,0 +1,3 @@
+Hier is nog een e-mail
+
+Verstuurd vanaf mijn iPhone


### PR DESCRIPTION
In this PR:
1. Use an array of signature regexes instead of a single one. This is similar to how it works for quote headers.
2. Added the Dutch "sent from my iPhone" signature.

Breaking changes:
1. `setQuoteHeadersRegex` and `getQuoteHeadersRegex` use arrays instead of strings. Applications using these methods must be updated.

Related to https://github.com/willdurand/EmailReplyParser/issues/69 but I went in a different direction.